### PR TITLE
feature: 상세 페이지 라우팅 설정 및 메인 페이지 UI 개선

### DIFF
--- a/src/components/main/FlowCard.tsx
+++ b/src/components/main/FlowCard.tsx
@@ -9,6 +9,7 @@ interface FlowCardProps {
   author: string;
   likes: number;
   views: string;
+  onClick?: () => void;
 }
 
 const CardContainer = styled.div`
@@ -123,7 +124,7 @@ const StatItem = styled.span`
   }
 `;
 
-const FlowCard = ({ image, title, author, likes, views }: FlowCardProps) => {
+const FlowCard = ({ image, title, author, likes, views, onClick }: FlowCardProps) => {
   const [imgSrc, setImgSrc] = useState(image || defaultThumbnail);
 
   const handleImageError = () => {
@@ -131,7 +132,7 @@ const FlowCard = ({ image, title, author, likes, views }: FlowCardProps) => {
   };
 
   return (
-    <CardContainer>
+    <CardContainer onClick={onClick}>
       <ImageWrapper>
         <img src={imgSrc} alt={title} onError={handleImageError} />
         <GradientOverlay className="card-hover-target" />

--- a/src/constants/path.ts
+++ b/src/constants/path.ts
@@ -2,4 +2,5 @@ export const PATH = {
     HOME: '/',
     LOGIN: '/login',
     SIGNUP: '/signup',
+    ARTIFACT_DETAIL: '/artifact/:id',
 } as const;

--- a/src/pages/DetailPage.tsx
+++ b/src/pages/DetailPage.tsx
@@ -1,0 +1,18 @@
+import styled from '@emotion/styled';
+
+const Container = styled.div`
+  padding: 100px 20px;
+  text-align: center;
+  font-size: 24px;
+  font-weight: bold;
+`;
+
+const DetailPage = () => {
+    return (
+        <Container>
+            상세페이지
+        </Container>
+    );
+};
+
+export default DetailPage;

--- a/src/pages/MainPage.tsx
+++ b/src/pages/MainPage.tsx
@@ -54,6 +54,8 @@ const Grid = styled.div`
 `;
 
 import { useEffect, useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { PATH } from '../constants/path';
 import { getArtifacts, searchArtifacts } from '../api/artifact';
 import type { Artifact } from '../types/artifact';
 import Spinner from '../components/common/Spinner';
@@ -61,6 +63,7 @@ import Spinner from '../components/common/Spinner';
 // ... (styled components)
 
 const MainPage = () => {
+    const navigate = useNavigate();
     const [flows, setFlows] = useState<Artifact[]>([]);
     const [loading, setLoading] = useState(true);
     const [error, setError] = useState<string | null>(null);
@@ -126,6 +129,7 @@ const MainPage = () => {
                                 author="AYNO User"
                                 likes={flow.likeCount}
                                 views={flow.viewCount.toLocaleString()}
+                                onClick={() => navigate(PATH.ARTIFACT_DETAIL.replace(':id', flow.artifactId.toString()))}
                             />
                         ))}
                     </Grid>

--- a/src/router.tsx
+++ b/src/router.tsx
@@ -2,6 +2,7 @@ import { createBrowserRouter } from 'react-router-dom';
 import { PATH } from './constants/path';
 import App from './App'; // 방금 만든 껍데기 import
 import MainPage from './pages/MainPage';
+import DetailPage from './pages/DetailPage';
 
 export const router = createBrowserRouter([
     {
@@ -12,6 +13,7 @@ export const router = createBrowserRouter([
                 path: PATH.HOME,
                 element: <MainPage />,
             },
+
             {
                 path: PATH.LOGIN,
                 element: <div>Login Page Content</div>,
@@ -19,6 +21,10 @@ export const router = createBrowserRouter([
             {
                 path: PATH.SIGNUP,
                 element: <div>Signup Page Content</div>,
+            },
+            {
+                path: PATH.ARTIFACT_DETAIL,
+                element: <DetailPage />,
             },
         ],
     },


### PR DESCRIPTION
# PR: 상세 페이지 라우팅 설정 및 메인 페이지 UI 개선

## 📝 개요
이 PR은 사용자가 [FlowCard](cci:1://file:///Users/yangjunsig/IdeaProjects/AynoFE_v2/src/components/main/FlowCard.tsx:126:0-149:2)를 클릭했을 때 상세 페이지로 이동할 수 있도록 라우팅 시스템을 구축하고, 메인 페이지의 불필요한 텍스트를 제거하여 UI를 깔끔하게 다듬는 작업을 포함합니다.

## ✨ 주요 변경 사항

### 1. 🛣️ 상세 페이지 라우팅 구현
- **라우터 설정**:
  - [src/pages/DetailPage.tsx](cci:7://file:///Users/yangjunsig/IdeaProjects/AynoFE_v2/src/pages/DetailPage.tsx:0:0-0:0)를 생성하여 상세 페이지의 기본 골격을 잡았습니다.
  - [router.tsx](cci:7://file:///Users/yangjunsig/IdeaProjects/AynoFE_v2/src/router.tsx:0:0-0:0)와 [path.ts](cci:7://file:///Users/yangjunsig/IdeaProjects/AynoFE_v2/src/constants/path.ts:0:0-0:0)에 `/artifact/:id` 경로를 추가하여 동적 라우팅을 설정했습니다.
- **네비게이션 연결**:
  - [MainPage](cci:1://file:///Users/yangjunsig/IdeaProjects/AynoFE_v2/src/pages/MainPage.tsx:64:0-146:2)에서 카드를 클릭하면 `useNavigate` 훅을 통해 해당 아티팩트의 ID를 포함한 상세 페이지 URL로 이동하도록 구현했습니다.

### 2. 👆 FlowCard 인터랙션 추가
- **클릭 이벤트 지원**: [FlowCard](cci:1://file:///Users/yangjunsig/IdeaProjects/AynoFE_v2/src/components/main/FlowCard.tsx:126:0-149:2) 컴포넌트에 `onClick` prop을 추가하여 외부에서 클릭 이벤트를 제어할 수 있게 했습니다.
- **UI 피드백**: 카드에 마우스를 올렸을 때 커서가 포인터(`cursor: pointer`)로 변경되도록 스타일을 수정하여, 클릭 가능한 요소임을 명확히 했습니다.

### 3. 🧹 메인 페이지 UI 정리
- **불필요한 텍스트 제거**: 섹션 제목 아래에 있던 "따끈따끈한 최신 AI 워크플로우를 만나보세요." 문구를 삭제하여, **'신규 프로젝트'** 제목에 더 집중할 수 있도록 심플한 레이아웃을 완성했습니다.

## 📸 작업 결과
- **기능**: 메인 페이지의 카드를 클릭하면 `/artifact/{id}` 경로로 정상 이동하며, "상세페이지" 텍스트가 표시됩니다.
- **디자인**: 섹션 설명 문구가 제거되어 더 간결해진 메인 화면을 제공합니다.