### PR TITLE
feature: 메인 페이지 API 데이터 연동 (작성자 정보 반영)

### DIFF
--- a/src/components/main/FlowCard.tsx
+++ b/src/components/main/FlowCard.tsx
@@ -7,6 +7,7 @@ interface FlowCardProps {
   image: string;
   title: string;
   author: string;
+  authorImage?: string;
   likes: number;
   views: string;
   onClick?: () => void;
@@ -77,10 +78,15 @@ const Author = styled.div`
   transition: all 0.3s ease;
   z-index: 10;
   
-  svg {
+  svg, img {
     width: 30px; /* Increased to 30px */
     height: 30px; /* Increased to 30px */
     filter: drop-shadow(0 1px 2px rgba(0,0,0,0.3));
+  }
+  
+  img {
+    border-radius: 50%;
+    object-fit: cover;
   }
 `;
 
@@ -123,7 +129,7 @@ const StatItem = styled.div`
   }
 `;
 
-const FlowCard = ({ image, title, author, likes, views, onClick }: FlowCardProps) => {
+const FlowCard = ({ image, title, author, authorImage, likes, views, onClick }: FlowCardProps) => {
   const [imgSrc, setImgSrc] = useState(image || defaultThumbnail);
 
   const handleImageError = () => {
@@ -135,7 +141,10 @@ const FlowCard = ({ image, title, author, likes, views, onClick }: FlowCardProps
       <ImageWrapper>
         <img src={imgSrc} alt={title} onError={handleImageError} />
         <GradientOverlay className="card-hover-target" />
-        <Author className="card-hover-target"><FiUser /> {author}</Author>
+        <Author className="card-hover-target">
+          {authorImage ? <img src={authorImage} alt={author} /> : <FiUser />}
+          {author}
+        </Author>
       </ImageWrapper>
       <ContentWrapper>
         <Title>{title}</Title>

--- a/src/pages/MainPage.tsx
+++ b/src/pages/MainPage.tsx
@@ -177,7 +177,8 @@ const MainPage = () => {
                                     key={flow.artifactId}
                                     image=""
                                     title={flow.artifactTitle}
-                                    author="AYNO User"
+                                    author={flow.nickname}
+                                    authorImage={flow.profileImageUrl}
                                     likes={flow.likeCount}
                                     views={flow.viewCount.toLocaleString()}
                                     onClick={() => navigate(PATH.ARTIFACT_DETAIL.replace(':id', flow.artifactId.toString()))}

--- a/src/types/artifact.ts
+++ b/src/types/artifact.ts
@@ -1,6 +1,9 @@
 export interface Artifact {
     artifactId: number;
     artifactTitle: string;
+    userId: number;
+    nickname: string;
+    profileImageUrl: string;
     aiUsagePercent: number;
     viewCount: number;
     likeCount: number;


### PR DESCRIPTION
# 🚀 PR: 메인 페이지 API 데이터 연동 (작성자 정보 반영)

## 📋 개요 (Summary)
백엔드 API 응답 스키마 변경에 따라, 메인 페이지의 카드 리스트에 **실제 작성자 정보(닉네임, 프로필 이미지)**가 표시되도록 데이터 연동 로직을 수정했습니다.

## 🛠 주요 변경 사항 (Key Changes)

### 1. 📦 타입 정의 업데이트 ([src/types/artifact.ts](cci:7://file:///Users/yangjunsig/IdeaProjects/AynoFE_v2/src/types/artifact.ts:0:0-0:0))
- [Artifact](cci:2://file:///Users/yangjunsig/IdeaProjects/AynoFE_v2/src/types/artifact.ts:0:0-12:1) 인터페이스에 새로운 필드 추가:
  - `userId`: 유저 고유 ID (PK)
  - `nickname`: 작성자 닉네임
  - `profileImageUrl`: 작성자 프로필 이미지 URL

### 2. 🃏 FlowCard 컴포넌트 개선 ([src/components/main/FlowCard.tsx](cci:7://file:///Users/yangjunsig/IdeaProjects/AynoFE_v2/src/components/main/FlowCard.tsx:0:0-0:0))
- **Props 확장**: `authorImage` (Optional) 속성 추가.
- **렌더링 로직 수정**:
  - `authorImage`가 존재할 경우: `<img>` 태그를 사용하여 프로필 이미지를 원형(`border-radius: 50%`)으로 렌더링.
  - `authorImage`가 없을 경우: 기존의 기본 아이콘(`FiUser`)을 유지.
- **스타일링**: 프로필 이미지와 텍스트가 자연스럽게 어우러지도록 이미지 크기(`30x30`) 및 `object-fit: cover` 속성 적용.

### 3. 🔗 데이터 바인딩 ([src/pages/MainPage.tsx](cci:7://file:///Users/yangjunsig/IdeaProjects/AynoFE_v2/src/pages/MainPage.tsx:0:0-0:0))
- API로부터 받아온 `nickname`과 `profileImageUrl`을 [FlowCard](cci:1://file:///Users/yangjunsig/IdeaProjects/AynoFE_v2/src/components/main/FlowCard.tsx:131:0-157:2) 컴포넌트의 `author` 및 `authorImage` props로 올바르게 전달하도록 매핑 수정.
- 기존 하드코딩된 "AYNO User" 제거.

## 📸 스크린샷 (Screenshots)
*(작성자 프로필 이미지가 적용된 카드 리스트 화면 캡처)*

## ✅ 체크리스트 (Checklist)
- [x] API 응답의 닉네임이 카드에 정상적으로 표시되는지 확인
- [x] 프로필 이미지가 있는 유저는 이미지가, 없는 유저는 기본 아이콘이 뜨는지 확인
- [x] 이미지 로딩 실패 시 에러 처리(기본 썸네일 등)가 기존 로직과 충돌 없는지 확인
