### PR TITLE
feature: FlowCard 이미지 상태 동기화 및 썸네일 API 연동

### DIFF
--- a/src/components/main/FlowCard.tsx
+++ b/src/components/main/FlowCard.tsx
@@ -1,17 +1,7 @@
 import styled from '@emotion/styled';
-import { useState } from 'react';
+import { useState, useEffect } from 'react';
 import defaultThumbnail from '../../assets/default_thumbnail.png';
 import { FiUser, FiThumbsUp, FiEye } from 'react-icons/fi';
-
-interface FlowCardProps {
-  image: string;
-  title: string;
-  author: string;
-  authorImage?: string;
-  likes: number;
-  views: string;
-  onClick?: () => void;
-}
 
 const CardContainer = styled.div`
   width: 430px; /* Fixed width as requested */
@@ -129,8 +119,22 @@ const StatItem = styled.div`
   }
 `;
 
+interface FlowCardProps {
+  image: string;
+  title: string;
+  author: string;
+  authorImage?: string;
+  likes: number;
+  views: string;
+  onClick?: () => void;
+}
+
 const FlowCard = ({ image, title, author, authorImage, likes, views, onClick }: FlowCardProps) => {
   const [imgSrc, setImgSrc] = useState(image || defaultThumbnail);
+
+  useEffect(() => {
+    setImgSrc(image || defaultThumbnail);
+  }, [image]);
 
   const handleImageError = () => {
     setImgSrc(defaultThumbnail);

--- a/src/pages/MainPage.tsx
+++ b/src/pages/MainPage.tsx
@@ -175,7 +175,7 @@ const MainPage = () => {
                             {flows.map(flow => (
                                 <FlowCard
                                     key={flow.artifactId}
-                                    image=""
+                                    image={flow.thumbnailUrl}
                                     title={flow.artifactTitle}
                                     author={flow.nickname}
                                     authorImage={flow.profileImageUrl}

--- a/src/types/artifact.ts
+++ b/src/types/artifact.ts
@@ -1,6 +1,7 @@
 export interface Artifact {
     artifactId: number;
     artifactTitle: string;
+    thumbnailUrl: string;
     userId: number;
     nickname: string;
     profileImageUrl: string;


### PR DESCRIPTION
# 🚀 PR: FlowCard 이미지 상태 동기화 및 썸네일 API 연동

## 📋 개요 (Summary)
카드 컴포넌트([FlowCard](cci:1://file:///Users/yangjunsig/IdeaProjects/AynoFE_v2/src/components/main/FlowCard.tsx:131:0-161:2))가 재사용될 때 이미지가 갱신되지 않는 버그를 수정하고, 백엔드 API에 추가된 **썸네일 URL**을 연동하여 실제 이미지를 표시하도록 개선했습니다.

## 🛠 주요 변경 사항 (Key Changes)

### 1. 🐛 버그 수정 ([src/components/main/FlowCard.tsx](cci:7://file:///Users/yangjunsig/IdeaProjects/AynoFE_v2/src/components/main/FlowCard.tsx:0:0-0:0))
- **이미지 상태 동기화**:
  - `useState`로 관리되던 `imgSrc`가 컴포넌트 최초 마운트 시에만 설정되어, 페이지네이션이나 필터링 시 props가 바뀌어도 이미지가 변경되지 않는 문제 해결.
  - `useEffect`를 추가하여 `image` props가 변경될 때마다 `imgSrc` 상태를 업데이트하도록 수정.

### 2. 🖼️ 썸네일 데이터 연동
- **타입 정의 ([src/types/artifact.ts](cci:7://file:///Users/yangjunsig/IdeaProjects/AynoFE_v2/src/types/artifact.ts:0:0-0:0))**:
  - [Artifact](cci:2://file:///Users/yangjunsig/IdeaProjects/AynoFE_v2/src/types/artifact.ts:0:0-13:1) 인터페이스에 `thumbnailUrl` 필드 추가.
- **데이터 바인딩 ([src/pages/MainPage.tsx](cci:7://file:///Users/yangjunsig/IdeaProjects/AynoFE_v2/src/pages/MainPage.tsx:0:0-0:0))**:
  - API 응답의 `thumbnailUrl`을 [FlowCard](cci:1://file:///Users/yangjunsig/IdeaProjects/AynoFE_v2/src/components/main/FlowCard.tsx:131:0-161:2)의 `image` prop으로 전달하도록 수정 (기존 빈 값 대체).

## ✅ 체크리스트 (Checklist)
- [x] 페이지 변경 또는 필터 적용 시 카드 이미지가 올바르게 바뀌는지 확인
- [x] API에서 받아온 썸네일이 정상적으로 표시되는지 확인
